### PR TITLE
Create verbose driver

### DIFF
--- a/verbose_driver.go
+++ b/verbose_driver.go
@@ -1,0 +1,40 @@
+package es
+
+import "github.com/rs/zerolog/log"
+
+// NewVerboseDriver creates a new VerboseDriver
+func NewVerboseDriver(driver Driver) *VerboseDriver {
+	return &VerboseDriver{Driver: driver}
+}
+
+// VerboseDriver implementation for deployed environments
+type VerboseDriver struct {
+	Driver Driver
+}
+
+// Load delegates to internal driver
+func (s *VerboseDriver) Load(aggregateID string) ([]*Event, error) {
+	return s.Driver.Load(aggregateID)
+}
+
+// Save delegates to internal driver and log all produced events
+func (s *VerboseDriver) Save(events []*Event) error {
+	err := s.Driver.Save(events)
+	if err != nil {
+		return err
+	}
+
+	for _, event := range events {
+		log.
+			Info().
+			Str("EventID", event.ID).
+			Str("EventType", event.Type).
+			Str("AggregateID", event.AggregateID).
+			Str("AggregateType", event.AggregateType).
+			Int64("AggregateVersion", event.AggregateVersion).
+			Time("Created", event.Created).
+			Msg("Produced event")
+	}
+
+	return nil
+}

--- a/verbose_driver_test.go
+++ b/verbose_driver_test.go
@@ -1,0 +1,50 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/indebted-modules/es"
+	"github.com/stretchr/testify/suite"
+)
+
+type VerboseDriverSuite struct {
+	suite.Suite
+}
+
+func TestVerboseDriverSuite(t *testing.T) {
+	suite.Run(t, new(VerboseDriverSuite))
+}
+
+type FakeDriver struct {
+	loadCalled bool
+	saveCalled bool
+}
+
+func (d *FakeDriver) Load(aggregateID string) ([]*es.Event, error) {
+	d.loadCalled = true
+	return nil, nil
+}
+
+func (d *FakeDriver) Save(events []*es.Event) error {
+	d.saveCalled = true
+	return nil
+}
+
+func (s *VerboseDriverSuite) TestDelegateLoadToInternalDriver() {
+	fakeDriver := &FakeDriver{}
+	verboseDriver := es.NewVerboseDriver(fakeDriver)
+
+	events, err := verboseDriver.Load("123")
+	s.Nil(events)
+	s.Nil(err)
+	s.True(fakeDriver.loadCalled)
+}
+
+func (s *VerboseDriverSuite) TestDelegateSaveToInternalDriver() {
+	fakeDriver := &FakeDriver{}
+	verboseDriver := es.NewVerboseDriver(fakeDriver)
+
+	err := verboseDriver.Save([]*es.Event{})
+	s.Nil(err)
+	s.True(fakeDriver.saveCalled)
+}


### PR DESCRIPTION
The verbose driver logs all saved events as `Info` the usage of the driver would be like

Without logs
```go
es.NewStore(es.NewDynamoDriver(cfg.MustEnv("EVENT_TABLE_NAME")))
```


With logs
```go
es.NewStore(es.NewVerboseDriver(es.NewDynamoDriver(cfg.MustEnv("EVENT_TABLE_NAME"))))
```