### PR TITLE
Add sequence id to in memory driver

### DIFF
--- a/in_memory_driver.go
+++ b/in_memory_driver.go
@@ -49,6 +49,7 @@ func (s *InMemoryDriver) Save(events []*Event) error {
 
 	for _, event := range events {
 		event.ID = string(newSequence)
+		event.Created = time.Now()
 		newSequence++
 
 		r, err := toRecord(event)

--- a/in_memory_driver.go
+++ b/in_memory_driver.go
@@ -102,7 +102,7 @@ func (s *InMemoryDriver) Stream() []*Event {
 	}
 
 	sort.Slice(events, func(i, j int) bool {
-		return events[i].Created.Before(events[j].Created)
+		return events[i].ID < events[j].ID
 	})
 
 	return events


### PR DESCRIPTION
Change InMemory driver to mimic what we have in the Postgres driver where:
- the driver generates an auto-incremental ID in order to keep the sequence of events;
- the driver supplies the date and time of the event's creation.  

The trigger of this change are the projections. When retrieving events from the store they need to be in the same order they were persisted to be reduced for the projections. 