### PR TITLE
Improve testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./.tmp/mmake:/usr/local/include/github.com
     environment:
       - DYNAMO_URL=http://dynamodb:8000
+      - POSTGRES_URL=postgres://user:password@postgres/indebted?sslmode=disable
     depends_on:
       - dynamodb
       - postgres

--- a/dynamo_driver_test.go
+++ b/dynamo_driver_test.go
@@ -27,7 +27,6 @@ func TestDynamoDriverSuite(t *testing.T) {
 }
 
 func (s *DynamoDriverSuite) SetupSuite() {
-	es.Register(EventType{})
 	s.TableName = fmt.Sprintf("store-test-%s", uuid.NewID())
 
 	s.Client = dynamodb.New(
@@ -80,11 +79,11 @@ func (s *DynamoDriverSuite) TestLoad() {
 		TableName: aws.String(s.TableName),
 		Item: map[string]*dynamodb.AttributeValue{
 			"ID":               {S: aws.String("load-event-id-1")},
-			"Type":             {S: aws.String("EventType")},
+			"Type":             {S: aws.String("SomethingHappened")},
 			"AggregateID":      {S: aws.String("load-aggregate-id")},
 			"AggregateType":    {S: aws.String("AggregateType")},
 			"AggregateVersion": {N: aws.String("0")},
-			"Payload":          {S: aws.String(`{"ID": "load-event-id-1"}`)},
+			"Payload":          {S: aws.String(`{"Data": "load-event-id-1"}`)},
 			"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 		},
 	})
@@ -94,11 +93,11 @@ func (s *DynamoDriverSuite) TestLoad() {
 		TableName: aws.String(s.TableName),
 		Item: map[string]*dynamodb.AttributeValue{
 			"ID":               {S: aws.String("load-event-id-2")},
-			"Type":             {S: aws.String("EventType")},
+			"Type":             {S: aws.String("SomethingHappened")},
 			"AggregateID":      {S: aws.String("load-aggregate-id")},
 			"AggregateType":    {S: aws.String("AggregateType")},
 			"AggregateVersion": {N: aws.String("1")},
-			"Payload":          {S: aws.String(`{"ID": "load-event-id-2"}`)},
+			"Payload":          {S: aws.String(`{"Data": "load-event-id-2"}`)},
 			"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 		},
 	})
@@ -108,11 +107,11 @@ func (s *DynamoDriverSuite) TestLoad() {
 		TableName: aws.String(s.TableName),
 		Item: map[string]*dynamodb.AttributeValue{
 			"ID":               {S: aws.String("load-event-id-3")},
-			"Type":             {S: aws.String("EventType")},
+			"Type":             {S: aws.String("SomethingHappened")},
 			"AggregateID":      {S: aws.String("load-another-aggregate-id")},
 			"AggregateType":    {S: aws.String("AggregateType")},
 			"AggregateVersion": {N: aws.String("0")},
-			"Payload":          {S: aws.String(`{"ID": "load-event-id-3"}`)},
+			"Payload":          {S: aws.String(`{"Data": "load-event-id-3"}`)},
 			"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 		},
 	})
@@ -124,21 +123,21 @@ func (s *DynamoDriverSuite) TestLoad() {
 
 	s.Equal(&es.Event{
 		ID:               "load-event-id-1",
-		Type:             "EventType",
+		Type:             "SomethingHappened",
 		AggregateID:      "load-aggregate-id",
 		AggregateType:    "AggregateType",
 		AggregateVersion: 0,
-		Payload:          &EventType{ID: "load-event-id-1"},
+		Payload:          &SomethingHappened{Data: "load-event-id-1"},
 		Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 	}, events[0])
 
 	s.Equal(&es.Event{
 		ID:               "load-event-id-2",
-		Type:             "EventType",
+		Type:             "SomethingHappened",
 		AggregateID:      "load-aggregate-id",
 		AggregateType:    "AggregateType",
 		AggregateVersion: 1,
-		Payload:          &EventType{ID: "load-event-id-2"},
+		Payload:          &SomethingHappened{Data: "load-event-id-2"},
 		Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 	}, events[1])
 
@@ -148,11 +147,11 @@ func (s *DynamoDriverSuite) TestLoad() {
 
 	s.Equal(&es.Event{
 		ID:               "load-event-id-3",
-		Type:             "EventType",
+		Type:             "SomethingHappened",
 		AggregateID:      "load-another-aggregate-id",
 		AggregateType:    "AggregateType",
 		AggregateVersion: 0,
-		Payload:          &EventType{ID: "load-event-id-3"},
+		Payload:          &SomethingHappened{Data: "load-event-id-3"},
 		Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 	}, events[0])
 }
@@ -161,29 +160,29 @@ func (s *DynamoDriverSuite) TestSave() {
 	events := []*es.Event{
 		{
 			ID:               "save-event-id-1",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "save-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "save-event-id-1"},
+			Payload:          &SomethingHappened{Data: "save-event-id-1"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			ID:               "save-event-id-2",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "save-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 1,
-			Payload:          &EventType{ID: "save-event-id-2"},
+			Payload:          &SomethingHappened{Data: "save-event-id-2"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			ID:               "save-event-id-3",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "save-another-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "save-event-id-3"},
+			Payload:          &SomethingHappened{Data: "save-event-id-3"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 	}
@@ -198,31 +197,31 @@ func (s *DynamoDriverSuite) TestSave() {
 
 	s.Contains(out.Items, map[string]*dynamodb.AttributeValue{
 		"ID":               {S: aws.String("save-event-id-1")},
-		"Type":             {S: aws.String("EventType")},
+		"Type":             {S: aws.String("SomethingHappened")},
 		"AggregateID":      {S: aws.String("save-aggregate-id")},
 		"AggregateType":    {S: aws.String("AggregateType")},
 		"AggregateVersion": {N: aws.String("0")},
-		"Payload":          {S: aws.String(`{"ID":"save-event-id-1"}`)},
+		"Payload":          {S: aws.String(`{"Data":"save-event-id-1"}`)},
 		"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 	})
 
 	s.Contains(out.Items, map[string]*dynamodb.AttributeValue{
 		"ID":               {S: aws.String("save-event-id-2")},
-		"Type":             {S: aws.String("EventType")},
+		"Type":             {S: aws.String("SomethingHappened")},
 		"AggregateID":      {S: aws.String("save-aggregate-id")},
 		"AggregateType":    {S: aws.String("AggregateType")},
 		"AggregateVersion": {N: aws.String("1")},
-		"Payload":          {S: aws.String(`{"ID":"save-event-id-2"}`)},
+		"Payload":          {S: aws.String(`{"Data":"save-event-id-2"}`)},
 		"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 	})
 
 	s.Contains(out.Items, map[string]*dynamodb.AttributeValue{
 		"ID":               {S: aws.String("save-event-id-3")},
-		"Type":             {S: aws.String("EventType")},
+		"Type":             {S: aws.String("SomethingHappened")},
 		"AggregateID":      {S: aws.String("save-another-aggregate-id")},
 		"AggregateType":    {S: aws.String("AggregateType")},
 		"AggregateVersion": {N: aws.String("0")},
-		"Payload":          {S: aws.String(`{"ID":"save-event-id-3"}`)},
+		"Payload":          {S: aws.String(`{"Data":"save-event-id-3"}`)},
 		"Created":          {S: aws.String("2019-06-30T00:00:00Z")},
 	})
 }
@@ -231,11 +230,11 @@ func (s *DynamoDriverSuite) TestSaveOptimisticLocking() {
 	events := []*es.Event{
 		{
 			ID:               "lock-event-id-1",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "lock-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "lock-event-id-1"},
+			Payload:          &SomethingHappened{Data: "lock-event-id-1"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 	}
@@ -246,11 +245,11 @@ func (s *DynamoDriverSuite) TestSaveOptimisticLocking() {
 	events = []*es.Event{
 		{
 			ID:               "lock-event-id-2",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "lock-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "lock-event-id-2"},
+			Payload:          &SomethingHappened{Data: "lock-event-id-2"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 	}
@@ -263,20 +262,20 @@ func (s *DynamoDriverSuite) TestSaveInTransaction() {
 	events := []*es.Event{
 		{
 			ID:               "tx-event-id-1",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "tx-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "tx-event-id-1"},
+			Payload:          &SomethingHappened{Data: "tx-event-id-1"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			ID:               "tx-event-id-2",
-			Type:             "EventType",
+			Type:             "SomethingHappened",
 			AggregateID:      "tx-aggregate-id",
 			AggregateType:    "AggregateType",
 			AggregateVersion: 0,
-			Payload:          &EventType{ID: "tx-event-id-2"},
+			Payload:          &SomethingHappened{Data: "tx-event-id-2"},
 			Created:          time.Date(2019, 6, 30, 0, 0, 0, 0, time.UTC),
 		},
 	}
@@ -288,10 +287,10 @@ func (s *DynamoDriverSuite) TestSaveInTransaction() {
 		TableName:      aws.String(s.TableName),
 		ConsistentRead: aws.Bool(true),
 		Key: map[string]*dynamodb.AttributeValue{
-			"AggregateID": &dynamodb.AttributeValue{
+			"AggregateID": {
 				S: aws.String("tx-aggregate-id"),
 			},
-			"AggregateVersion": &dynamodb.AttributeValue{
+			"AggregateVersion": {
 				N: aws.String("0"),
 			},
 		},

--- a/dynamo_driver_test.go
+++ b/dynamo_driver_test.go
@@ -22,18 +22,6 @@ type DynamoDriverSuite struct {
 	TableName string
 }
 
-type EventType struct {
-	ID string
-}
-
-func (EventType) PayloadType() string {
-	return "EventType"
-}
-
-func (EventType) AggregateType() string {
-	return "AggregateType"
-}
-
 func TestDynamoDriverSuite(t *testing.T) {
 	suite.Run(t, new(DynamoDriverSuite))
 }

--- a/event_test.go
+++ b/event_test.go
@@ -13,21 +13,9 @@ type EventSuite struct {
 	suite.Suite
 }
 
-type SampleAggregate struct {
-	es.Versionable
-}
-
-type AnotherSampleAggregate struct {
-	es.Versionable
-}
-
 func TestEventSuite(t *testing.T) {
 	suite.Run(t, new(EventSuite))
 }
-
-func (SampleAggregate) Reduce(typ string, payload interface{}) {}
-
-func (AnotherSampleAggregate) Reduce(typ string, payload interface{}) {}
 
 func (s *EventSuite) TestNewEvent() {
 	somethingHappened := &SomethingHappened{}

--- a/postgres_driver_test.go
+++ b/postgres_driver_test.go
@@ -16,12 +16,6 @@ type PostgresDriverSuite struct {
 	driver es.Driver
 }
 
-type TestPayload struct{ Data string }
-
-func (TestPayload) PayloadType() string   { return "TestPayload" }
-func (TestPayload) AggregateType() string { return "AggregateType" }
-func init()                               { es.Register(TestPayload{}) }
-
 type Row struct {
 	ID               int64
 	Type             string
@@ -80,7 +74,7 @@ func (s *PostgresDriverSuite) TestLoad() {
 
 	_, err = stmt.Exec(
 		1,
-		"TestPayload",
+		"SomethingHappened",
 		time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 		phonyUUID(1),
 		0,
@@ -91,7 +85,7 @@ func (s *PostgresDriverSuite) TestLoad() {
 
 	_, err = stmt.Exec(
 		2,
-		"TestPayload",
+		"SomethingHappened",
 		time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 		phonyUUID(2),
 		0,
@@ -102,7 +96,7 @@ func (s *PostgresDriverSuite) TestLoad() {
 
 	_, err = stmt.Exec(
 		3,
-		"TestPayload",
+		"SomethingHappened",
 		time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 		phonyUUID(1),
 		1,
@@ -116,21 +110,21 @@ func (s *PostgresDriverSuite) TestLoad() {
 	s.Equal([]*es.Event{
 		{
 			ID:               "1",
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V0"},
 		},
 		{
 			ID:               "3",
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 1,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V1"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V1"},
 		},
 	}, events)
 
@@ -139,12 +133,12 @@ func (s *PostgresDriverSuite) TestLoad() {
 	s.Equal([]*es.Event{
 		{
 			ID:               "2",
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(2),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#2 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#2 - V0"},
 		},
 	}, events)
 }
@@ -152,25 +146,25 @@ func (s *PostgresDriverSuite) TestLoad() {
 func (s *PostgresDriverSuite) TestSave() {
 	events := []*es.Event{
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V0"},
 		},
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 1,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V1"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V1"},
 		},
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			AggregateID:      phonyUUID(2),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#2 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#2 - V0"},
 		},
 	}
 
@@ -195,7 +189,7 @@ func (s *PostgresDriverSuite) TestSave() {
 	s.Equal([]*Row{
 		{
 			ID:               1,
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 0,
@@ -204,7 +198,7 @@ func (s *PostgresDriverSuite) TestSave() {
 		},
 		{
 			ID:               2,
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 1,
@@ -213,7 +207,7 @@ func (s *PostgresDriverSuite) TestSave() {
 		},
 		{
 			ID:               3,
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(2),
 			AggregateVersion: 0,
@@ -226,12 +220,12 @@ func (s *PostgresDriverSuite) TestSave() {
 func (s *PostgresDriverSuite) TestSaveOptimisticLocking() {
 	events := []*es.Event{
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V0"},
 		},
 	}
 
@@ -240,12 +234,12 @@ func (s *PostgresDriverSuite) TestSaveOptimisticLocking() {
 
 	events = []*es.Event{
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      phonyUUID(1),
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - V0"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - V0"},
 		},
 	}
 
@@ -257,20 +251,20 @@ func (s *PostgresDriverSuite) TestSaveOptimisticLocking() {
 func (s *PostgresDriverSuite) TestSaveInTransaction() {
 	events := []*es.Event{
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      "AggregateID#1 - TX",
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - TX"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - TX"},
 		},
 		{
-			Type:             "TestPayload",
+			Type:             "SomethingHappened",
 			Created:          time.Date(1985, time.October, 26, 1, 22, 0, 0, time.UTC),
 			AggregateID:      "AggregateID#1 - TX",
 			AggregateVersion: 0,
 			AggregateType:    "AggregateType",
-			Payload:          &TestPayload{Data: "AggregateID#1 - TX"},
+			Payload:          &SomethingHappened{Data: "AggregateID#1 - TX"},
 		},
 	}
 

--- a/postgres_driver_test.go
+++ b/postgres_driver_test.go
@@ -3,6 +3,7 @@ package es_test
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestPostgresDriverSuite(t *testing.T) {
 }
 
 func (s *PostgresDriverSuite) SetupTest() {
-	s.db = es.MustConnect("postgres://user:password@postgres/indebted?sslmode=disable")
+	s.db = es.MustConnect(os.Getenv("POSTGRES_URL"))
 
 	_, err := s.db.Exec(`
 		CREATE SCHEMA stub; CREATE FUNCTION stub.now() RETURNS TIMESTAMPTZ LANGUAGE SQL AS $$ SELECT '1985-10-26 01:22+00'::timestamptz; $$;

--- a/projection.go
+++ b/projection.go
@@ -1,10 +1,6 @@
 package es
 
 // Projection abstraction
-type Projection struct {
-	version int64
-}
-
-func (v *Projection) setVersion(version int64) {
-	v.version = version
+type Projection interface {
+	Reduce(event Event)
 }

--- a/projection.go
+++ b/projection.go
@@ -1,6 +1,10 @@
 package es
 
 // Projection abstraction
-type Projection interface {
-	Reduce(event Event)
+type Projection struct {
+	version int64
+}
+
+func (v *Projection) setVersion(version int64) {
+	v.version = version
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -15,22 +15,6 @@ func TestRegistrySuite(t *testing.T) {
 	suite.Run(t, new(RegistrySuite))
 }
 
-type SomethingHappened struct{}
-
-func (SomethingHappened) PayloadType() string {
-	return "SomethingHappened"
-}
-func (SomethingHappened) AggregateType() string {
-	return "SampleAggregate"
-}
-
-type SomethingElseHappened struct{}
-
-func (SomethingElseHappened) PayloadType() string { return "SomethingElseHappened" }
-func (SomethingElseHappened) AggregateType() string {
-	return "AnotherSampleAggregate"
-}
-
 func (s *RegistrySuite) TestResolveTypeFailsIfTypeNotRegistered() {
 	r := es.NewRegistry()
 	event, err := r.ResolveType("UnregisteredType")

--- a/store_test.go
+++ b/store_test.go
@@ -39,6 +39,20 @@ func (s *StoreSuite) TestStoreLoad() {
 	s.Equal([]string{"event-3", "event-4", "event-5"}, anotherAggregate.ReducedData)
 }
 
+func (s *StoreSuite) TestStoreSave() {
+	driver := es.NewInMemoryDriver()
+	store := es.NewStore(driver)
+
+	sampleAggregate := &SampleAggregate{}
+	err := store.Save(sampleAggregate.DoSomething("1", []string{"event-1", "event-2"}))
+	s.NoError(err)
+
+	stream := driver.Stream()
+	s.Equal(2, len(stream))
+	s.Equal(stream[0].Payload, &SomethingHappened{Data: "event-1"})
+	s.Equal(stream[1].Payload, &SomethingHappened{Data: "event-2"})
+}
+
 func (s *StoreSuite) TestLoadWithEmptyAggregateID() {
 	store := es.NewStore(&BrokenDriver{ErrorMessage: "driver should not have been called"})
 

--- a/store_test.go
+++ b/store_test.go
@@ -15,6 +15,29 @@ func TestStoreSuite(t *testing.T) {
 	suite.Run(t, new(StoreSuite))
 }
 
+func (s *StoreSuite) TestLoad() {
+	driver := es.NewInMemoryDriver()
+	err := driver.Save([]*es.Event{
+		es.NewEvent("1", &SomethingHappened{Data: "event-1"}),
+		es.NewEvent("1", &SomethingHappened{Data: "event-2"}),
+		es.NewEvent("2", &SomethingElseHappened{Data: "event-3"}),
+		es.NewEvent("2", &SomethingElseHappened{Data: "event-4"}),
+	})
+	s.NoError(err)
+
+	store := es.NewStore(driver)
+
+	sampleAggregate := &SampleAggregate{}
+	err = store.Load("1", sampleAggregate)
+	s.NoError(err)
+	s.Equal([]string{"event-1", "event-2"}, sampleAggregate.ReducedData)
+
+	anotherAggregate := &AnotherSampleAggregate{}
+	err = store.Load("2", anotherAggregate)
+	s.NoError(err)
+	s.Equal([]string{"event-3", "event-4"}, anotherAggregate.ReducedData)
+}
+
 func (s *StoreSuite) TestLoadWithEmptyAggregateID() {
 	store := es.NewStore(&BrokenDriver{ErrorMessage: "driver should not have been called"})
 

--- a/store_test.go
+++ b/store_test.go
@@ -1,7 +1,6 @@
 package es_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/indebted-modules/es"

--- a/store_test.go
+++ b/store_test.go
@@ -16,17 +16,6 @@ func TestStoreSuite(t *testing.T) {
 	suite.Run(t, new(StoreSuite))
 }
 
-type BrokenDriver struct {
-	ErrorMessage string
-}
-
-func (d *BrokenDriver) Load(aggregateID string) ([]*es.Event, error) {
-	return nil, fmt.Errorf(d.ErrorMessage)
-}
-
-func (d *BrokenDriver) Save(events []*es.Event) error {
-	return fmt.Errorf(d.ErrorMessage)
-}
 func (s *StoreSuite) TestLoadWithEmptyAggregateID() {
 	store := es.NewStore(&BrokenDriver{ErrorMessage: "driver should not have been called"})
 

--- a/support_test.go
+++ b/support_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/indebted-modules/es"
 )
 
-// SampleAggregate .
+// SampleAggregate sample aggregate for testing
 type SampleAggregate struct {
 	es.Versionable
 	ReducedData []string
@@ -20,7 +20,7 @@ func (s *SampleAggregate) Reduce(typ string, payload interface{}) {
 	}
 }
 
-// DoSomething command does validation and returns events
+// DoSomething commands do validation and return events
 func (s *SampleAggregate) DoSomething(id string, data []string) []*es.AppliedEvent {
 	events := []*es.Event{}
 
@@ -31,7 +31,7 @@ func (s *SampleAggregate) DoSomething(id string, data []string) []*es.AppliedEve
 	return s.Apply(s, events)
 }
 
-// AnotherSampleAggregate .
+// AnotherSampleAggregate another sample aggregate for testing
 type AnotherSampleAggregate struct {
 	es.Versionable
 	ReducedData []string
@@ -45,7 +45,7 @@ func (a *AnotherSampleAggregate) Reduce(typ string, payload interface{}) {
 	}
 }
 
-// DoSomethingElse command does validation and returns events
+// DoSomethingElse commands do validation and return events
 func (a *AnotherSampleAggregate) DoSomethingElse(id string, data []string) []*es.AppliedEvent {
 	events := []*es.Event{}
 
@@ -56,7 +56,7 @@ func (a *AnotherSampleAggregate) DoSomethingElse(id string, data []string) []*es
 	return a.Apply(a, events)
 }
 
-// BrokenDriver .
+// BrokenDriver always returns error for testing error cases
 type BrokenDriver struct {
 	ErrorMessage string
 }
@@ -69,7 +69,7 @@ func (d *BrokenDriver) Save(_ []*es.Event) error {
 	return fmt.Errorf(d.ErrorMessage)
 }
 
-// SomethingHappened .
+// SomethingHappened event sample for testing
 type SomethingHappened struct {
 	Data string
 }
@@ -82,7 +82,7 @@ func (SomethingHappened) AggregateType() string {
 	return "SampleAggregate"
 }
 
-// SomethingElseHappened
+// SomethingElseHappened another event sample for testing
 type SomethingElseHappened struct {
 	Data string
 }

--- a/support_test.go
+++ b/support_test.go
@@ -8,10 +8,29 @@ import (
 // SampleAggregate .
 type SampleAggregate struct {
 	es.Versionable
+	ReducedData []string
 }
 
-func (SampleAggregate) Reduce(typ string, payload interface{}) {
+func (s *SampleAggregate) Reduce(typ string, payload interface{}) {
+	switch typ {
+	case "SomethingHappened":
+		event := payload.(SomethingHappened)
+		s.ReducedData = append(s.ReducedData, event.Data)
+	}
+}
 
+// AnotherSampleAggregate .
+type AnotherSampleAggregate struct {
+	es.Versionable
+	ReducedData []string
+}
+
+func (a *AnotherSampleAggregate) Reduce(typ string, payload interface{}) {
+	switch typ {
+	case "SomethingElseHappened":
+		event := payload.(SomethingElseHappened)
+		a.ReducedData = append(a.ReducedData, event.Data)
+	}
 }
 
 // BrokenDriver .

--- a/support_test.go
+++ b/support_test.go
@@ -14,22 +14,6 @@ func (SampleAggregate) Reduce(typ string, payload interface{}) {
 
 }
 
-// FakeDriver .
-type FakeDriver struct {
-	loadCalled bool
-	saveCalled bool
-}
-
-func (d *FakeDriver) Load(aggregateID string) ([]*es.Event, error) {
-	d.loadCalled = true
-	return nil, nil
-}
-
-func (d *FakeDriver) Save(events []*es.Event) error {
-	d.saveCalled = true
-	return nil
-}
-
 // BrokenDriver .
 type BrokenDriver struct {
 	ErrorMessage string
@@ -78,4 +62,9 @@ func (EventType) PayloadType() string {
 
 func (EventType) AggregateType() string {
 	return "AggregateType"
+}
+
+func init() {
+	es.Register(SomethingHappened{})
+	es.Register(SomethingElseHappened{})
 }

--- a/support_test.go
+++ b/support_test.go
@@ -20,6 +20,17 @@ func (s *SampleAggregate) Reduce(typ string, payload interface{}) {
 	}
 }
 
+// DoSomething command does validation and returns events
+func (s *SampleAggregate) DoSomething(id string, data []string) []*es.AppliedEvent {
+	events := []*es.Event{}
+
+	for i := range data {
+		events = append(events, es.NewEvent(id, &SomethingHappened{Data: data[i]}))
+	}
+
+	return s.Apply(s, events)
+}
+
 // AnotherSampleAggregate .
 type AnotherSampleAggregate struct {
 	es.Versionable
@@ -32,6 +43,17 @@ func (a *AnotherSampleAggregate) Reduce(typ string, payload interface{}) {
 		event := payload.(*SomethingElseHappened)
 		a.ReducedData = append(a.ReducedData, event.Data)
 	}
+}
+
+// DoSomethingElse command does validation and returns events
+func (a *AnotherSampleAggregate) DoSomethingElse(id string, data []string) []*es.AppliedEvent {
+	events := []*es.Event{}
+
+	for i := range data {
+		events = append(events, es.NewEvent(id, &SomethingElseHappened{Data: data[i]}))
+	}
+
+	return a.Apply(a, events)
 }
 
 // BrokenDriver .

--- a/support_test.go
+++ b/support_test.go
@@ -2,6 +2,7 @@ package es_test
 
 import (
 	"fmt"
+
 	"github.com/indebted-modules/es"
 )
 
@@ -14,7 +15,7 @@ type SampleAggregate struct {
 func (s *SampleAggregate) Reduce(typ string, payload interface{}) {
 	switch typ {
 	case "SomethingHappened":
-		event := payload.(SomethingHappened)
+		event := payload.(*SomethingHappened)
 		s.ReducedData = append(s.ReducedData, event.Data)
 	}
 }
@@ -28,7 +29,7 @@ type AnotherSampleAggregate struct {
 func (a *AnotherSampleAggregate) Reduce(typ string, payload interface{}) {
 	switch typ {
 	case "SomethingElseHappened":
-		event := payload.(SomethingElseHappened)
+		event := payload.(*SomethingElseHappened)
 		a.ReducedData = append(a.ReducedData, event.Data)
 	}
 }

--- a/support_test.go
+++ b/support_test.go
@@ -29,6 +29,7 @@ func (d *BrokenDriver) Save(_ []*es.Event) error {
 
 // SomethingHappened .
 type SomethingHappened struct {
+	Data string
 }
 
 func (SomethingHappened) PayloadType() string {
@@ -41,6 +42,7 @@ func (SomethingHappened) AggregateType() string {
 
 // SomethingElseHappened
 type SomethingElseHappened struct {
+	Data string
 }
 
 func (SomethingElseHappened) PayloadType() string {

--- a/support_test.go
+++ b/support_test.go
@@ -1,0 +1,81 @@
+package es_test
+
+import (
+	"fmt"
+	"github.com/indebted-modules/es"
+)
+
+// SampleAggregate .
+type SampleAggregate struct {
+	es.Versionable
+}
+
+func (SampleAggregate) Reduce(typ string, payload interface{}) {
+
+}
+
+// FakeDriver .
+type FakeDriver struct {
+	loadCalled bool
+	saveCalled bool
+}
+
+func (d *FakeDriver) Load(aggregateID string) ([]*es.Event, error) {
+	d.loadCalled = true
+	return nil, nil
+}
+
+func (d *FakeDriver) Save(events []*es.Event) error {
+	d.saveCalled = true
+	return nil
+}
+
+// BrokenDriver .
+type BrokenDriver struct {
+	ErrorMessage string
+}
+
+func (d *BrokenDriver) Load(_ string) ([]*es.Event, error) {
+	return nil, fmt.Errorf(d.ErrorMessage)
+}
+
+func (d *BrokenDriver) Save(_ []*es.Event) error {
+	return fmt.Errorf(d.ErrorMessage)
+}
+
+// SomethingHappened .
+type SomethingHappened struct {
+}
+
+func (SomethingHappened) PayloadType() string {
+	return "SomethingHappened"
+}
+
+func (SomethingHappened) AggregateType() string {
+	return "SampleAggregate"
+}
+
+// SomethingElseHappened
+type SomethingElseHappened struct {
+}
+
+func (SomethingElseHappened) PayloadType() string {
+	return "SomethingElseHappened"
+}
+
+func (SomethingElseHappened) AggregateType() string {
+	return "AnotherSampleAggregate"
+}
+
+// EventType .
+type EventType struct {
+	ID string
+}
+
+func (EventType) PayloadType() string {
+	return "EventType"
+}
+
+func (EventType) AggregateType() string {
+	return "AggregateType"
+}

--- a/support_test.go
+++ b/support_test.go
@@ -53,19 +53,6 @@ func (SomethingElseHappened) AggregateType() string {
 	return "AnotherSampleAggregate"
 }
 
-// EventType .
-type EventType struct {
-	ID string
-}
-
-func (EventType) PayloadType() string {
-	return "EventType"
-}
-
-func (EventType) AggregateType() string {
-	return "AggregateType"
-}
-
 func init() {
 	es.Register(SomethingHappened{})
 	es.Register(SomethingElseHappened{})

--- a/use_case_test.go
+++ b/use_case_test.go
@@ -1,0 +1,78 @@
+package es_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/indebted-modules/es"
+	"github.com/stretchr/testify/suite"
+)
+
+type UseCaseSuite struct {
+	suite.Suite
+}
+
+func TestUseCaseSuite(t *testing.T) {
+	suite.Run(t, new(UseCaseSuite))
+}
+
+func (s *UseCaseSuite) TestAggregateLifecycle() {
+	store := es.NewStore(es.NewInMemoryDriver())
+
+	sampleAggregate := &SampleAggregate{}
+	events := sampleAggregate.DoSomething("1", []string{"event-1", "event-2"})
+	err := store.Save(events)
+	s.NoError(err)
+	s.Equal(
+		[]string{"event-1", "event-2"},
+		sampleAggregate.ReducedData,
+		"Apply events during memory lifecycle",
+	)
+
+	newInMemoryCycle := &SampleAggregate{}
+	err = store.Load("1", newInMemoryCycle)
+	s.NoError(err)
+	s.Equal(
+		[]string{"event-1", "event-2"},
+		newInMemoryCycle.ReducedData,
+		"Re-apply events when loading aggregate to memory again",
+	)
+}
+
+func (s *UseCaseSuite) TestConcurrentWriting() {
+	store := es.NewStore(es.NewInMemoryDriver())
+
+	sampleAggregate := &SampleAggregate{}
+	events := sampleAggregate.DoSomething("1", []string{"event-1", "event-2"})
+	err := store.Save(events)
+	s.NoError(err)
+
+	newInMemory1 := &SampleAggregate{}
+	err = store.Load("1", newInMemory1)
+	s.NoError(err)
+
+	newInMemory2 := &SampleAggregate{}
+	err = store.Load("1", newInMemory2)
+	s.NoError(err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		_ = store.Save(newInMemory1.DoSomething("1", []string{"event-3"}))
+		wg.Done()
+	}()
+	go func() {
+		_ = store.Save(newInMemory2.DoSomething("1", []string{"event-3"}))
+		wg.Done()
+	}()
+	wg.Wait()
+
+	newInMemoryCycle := &SampleAggregate{}
+	err = store.Load("1", newInMemoryCycle)
+	s.NoError(err)
+	s.Equal(
+		[]string{"event-1", "event-2", "event-3"},
+		newInMemoryCycle.ReducedData,
+		"Don't apply events to stale aggregates",
+	)
+}

--- a/verbose_driver_test.go
+++ b/verbose_driver_test.go
@@ -16,20 +16,21 @@ func TestVerboseDriverSuite(t *testing.T) {
 }
 
 func (s *VerboseDriverSuite) TestDelegateLoadToInternalDriver() {
-	fakeDriver := &FakeDriver{}
-	verboseDriver := es.NewVerboseDriver(fakeDriver)
+	driver := es.NewInMemoryDriver()
+	err := driver.Save([]*es.Event{es.NewEvent("123", &SomethingHappened{})})
+	s.NoError(err)
 
+	verboseDriver := es.NewVerboseDriver(driver)
 	events, err := verboseDriver.Load("123")
-	s.Nil(events)
-	s.Nil(err)
-	s.True(fakeDriver.loadCalled)
+	s.NoError(err)
+	s.Equal(&SomethingHappened{}, events[0].Payload)
 }
 
 func (s *VerboseDriverSuite) TestDelegateSaveToInternalDriver() {
-	fakeDriver := &FakeDriver{}
-	verboseDriver := es.NewVerboseDriver(fakeDriver)
+	driver := es.NewInMemoryDriver()
+	verboseDriver := es.NewVerboseDriver(driver)
 
-	err := verboseDriver.Save([]*es.Event{})
-	s.Nil(err)
-	s.True(fakeDriver.saveCalled)
+	err := verboseDriver.Save([]*es.Event{es.NewEvent("123", &SomethingHappened{})})
+	s.NoError(err)
+	s.Equal(&SomethingHappened{}, driver.Stream()[0].Payload)
 }

--- a/verbose_driver_test.go
+++ b/verbose_driver_test.go
@@ -15,21 +15,6 @@ func TestVerboseDriverSuite(t *testing.T) {
 	suite.Run(t, new(VerboseDriverSuite))
 }
 
-type FakeDriver struct {
-	loadCalled bool
-	saveCalled bool
-}
-
-func (d *FakeDriver) Load(aggregateID string) ([]*es.Event, error) {
-	d.loadCalled = true
-	return nil, nil
-}
-
-func (d *FakeDriver) Save(events []*es.Event) error {
-	d.saveCalled = true
-	return nil
-}
-
 func (s *VerboseDriverSuite) TestDelegateLoadToInternalDriver() {
 	fakeDriver := &FakeDriver{}
 	verboseDriver := es.NewVerboseDriver(fakeDriver)


### PR DESCRIPTION
Improves overall testing of the package

* Move all test support objects to a seperate file to avoid name collisions and make it more reusable
* Remove duplicated fakes
* Test store struct 
* Create use case tests for integrated testing and documentation purpose
* Make PostgreSQL connection url configurable per environment